### PR TITLE
Implement message search with snippet results

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@
 - **Keyboard Shortcuts** - Full keyboard navigation support for power users
 - **Chat Management** - Pin important chats, export/import history, edit titles, and create conversation branches
 - **User Personalization** - Customize AI behavior with personal traits, occupation details, and preferences
+- **Advanced Search** - Quickly find messages with full-text search snippets
 - **Message Usage Tracking** - Visual indicators for daily/monthly message limits and premium credits (to be implemented)
 - **Responsive Mobile UI** - Optimized mobile experience with drawer-based navigation
 

--- a/app/components/chat/chat.tsx
+++ b/app/components/chat/chat.tsx
@@ -19,7 +19,7 @@ import { useChat, type Message } from "@ai-sdk/react"
 import { useAction, useConvex, useMutation, useQuery } from "convex/react"
 import { AnimatePresence, motion } from "framer-motion"
 import dynamic from "next/dynamic"
-import { useRouter } from "next/navigation"
+import { useRouter, useSearchParams } from "next/navigation"
 import { useCallback, useEffect, useState } from "react"
 
 const DialogAuth = dynamic(
@@ -61,6 +61,7 @@ function humaniseUploadError(err: unknown): string {
 export default function Chat() {
   const { chatId, isDeleting, setIsDeleting } = useChatSession()
   const router = useRouter()
+  const searchParams = useSearchParams()
   const { user, isLoading: isUserLoading } = useUser()
 
   // --- Convex Data Hooks ---
@@ -587,6 +588,15 @@ export default function Chat() {
       setSelectedModel(user.preferredModel)
     }
   }, [user?.preferredModel, chatId])
+
+  const targetMessageId = searchParams.get("m")
+  useEffect(() => {
+    if (!targetMessageId) return
+    const el = document.getElementById(targetMessageId)
+    if (el) {
+      el.scrollIntoView({ block: "center" })
+    }
+  }, [targetMessageId, messages])
 
   if (currentChat === null && chatId) {
     return null // Render nothing while redirecting

--- a/app/components/chat/chat.tsx
+++ b/app/components/chat/chat.tsx
@@ -20,7 +20,7 @@ import { useAction, useConvex, useMutation, useQuery } from "convex/react"
 import { AnimatePresence, motion } from "framer-motion"
 import dynamic from "next/dynamic"
 import { useRouter, useSearchParams } from "next/navigation"
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 
 const DialogAuth = dynamic(
   () => import("./dialog-auth").then((mod) => mod.DialogAuth),
@@ -590,11 +590,23 @@ export default function Chat() {
   }, [user?.preferredModel, chatId])
 
   const targetMessageId = searchParams.get("m")
+  const [autoScroll, setAutoScroll] = useState(() => !targetMessageId)
+  const hasScrolledRef = useRef(false)
+
   useEffect(() => {
-    if (!targetMessageId) return
+    if (targetMessageId) {
+      setAutoScroll(false)
+      hasScrolledRef.current = false
+    }
+  }, [targetMessageId])
+
+  useEffect(() => {
+    if (!targetMessageId || hasScrolledRef.current) return
     const el = document.getElementById(targetMessageId)
     if (el) {
       el.scrollIntoView({ block: "center" })
+      hasScrolledRef.current = true
+      setAutoScroll(true)
     }
   }, [targetMessageId, messages])
 
@@ -634,6 +646,7 @@ export default function Chat() {
             onEdit={handleEdit}
             onReload={handleReload}
             onBranch={handleBranch}
+            autoScroll={autoScroll}
           />
         )}
       </AnimatePresence>

--- a/app/components/chat/chat.tsx
+++ b/app/components/chat/chat.tsx
@@ -590,23 +590,21 @@ export default function Chat() {
   }, [user?.preferredModel, chatId])
 
   const targetMessageId = searchParams.get("m")
-  const [autoScroll, setAutoScroll] = useState(() => !targetMessageId)
   const hasScrolledRef = useRef(false)
 
   useEffect(() => {
     if (targetMessageId) {
-      setAutoScroll(false)
       hasScrolledRef.current = false
     }
   }, [targetMessageId])
 
   useEffect(() => {
-    if (!targetMessageId || hasScrolledRef.current) return
+    if (!targetMessageId || hasScrolledRef.current || messages.length === 0)
+      return
     const el = document.getElementById(targetMessageId)
     if (el) {
-      el.scrollIntoView({ block: "center" })
+      el.scrollIntoView({ block: "center", behavior: "smooth" })
       hasScrolledRef.current = true
-      setAutoScroll(true)
     }
   }, [targetMessageId, messages])
 
@@ -646,7 +644,7 @@ export default function Chat() {
             onEdit={handleEdit}
             onReload={handleReload}
             onBranch={handleBranch}
-            autoScroll={autoScroll}
+            autoScroll={!targetMessageId}
           />
         )}
       </AnimatePresence>

--- a/app/components/chat/conversation.tsx
+++ b/app/components/chat/conversation.tsx
@@ -17,6 +17,7 @@ type ConversationProps = {
   onEdit: (id: string, newText: string) => void
   onReload: (id: string) => void
   onBranch: (messageId: string) => void
+  autoScroll?: boolean
 }
 
 const Conversation = React.memo(function Conversation({
@@ -26,6 +27,7 @@ const Conversation = React.memo(function Conversation({
   onEdit,
   onReload,
   onBranch,
+  autoScroll = true,
 }: ConversationProps) {
   const initialMessageCount = useRef(messages.length)
   const scrollRef = useRef<HTMLDivElement>(null)
@@ -38,7 +40,7 @@ const Conversation = React.memo(function Conversation({
     <div className="relative flex h-full w-full flex-col items-center overflow-x-hidden overflow-y-auto">
       <ChatContainer
         className="relative flex w-full flex-col items-center pt-20 pb-4"
-        autoScroll={true}
+        autoScroll={autoScroll}
         ref={containerRef}
         scrollToRef={scrollRef}
         style={{

--- a/app/components/chat/message-assistant.tsx
+++ b/app/components/chat/message-assistant.tsx
@@ -49,7 +49,8 @@ type MessageAssistantProps = {
   attachments?: MessageType["experimental_attachments"]
   status?: "streaming" | "ready" | "submitted" | "error"
   reasoning_text?: string
-}
+  id: string
+} 
 
 const Markdown = dynamic(
   () => import("@/components/prompt-kit/markdown").then((mod) => mod.Markdown),
@@ -69,6 +70,7 @@ function MessageAssistantInner({
   attachments,
   status,
   reasoning_text,
+  id,
 }: MessageAssistantProps) {
   const [showReasoning, setShowReasoning] = useState(status === "streaming") // Collapsed by default, open if streaming
   const prevStatusRef = useRef(status) // Ref to track previous status
@@ -191,6 +193,7 @@ function MessageAssistantInner({
 
   return (
     <Message
+      id={id}
       className={cn(
         "group flex w-full max-w-3xl flex-1 items-start gap-4 px-6 pb-2",
         hasScrollAnchor && "min-h-scroll-anchor"

--- a/app/components/chat/message-user.tsx
+++ b/app/components/chat/message-user.tsx
@@ -81,6 +81,7 @@ function MessageUserInner({
 
   return (
     <MessageContainer
+      id={id}
       className={cn(
         "group flex w-full max-w-3xl flex-col items-end gap-2 px-6 pb-2",
         hasScrollAnchor && "min-h-scroll-anchor"

--- a/app/components/chat/message.tsx
+++ b/app/components/chat/message.tsx
@@ -65,6 +65,7 @@ export function Message({
   if (variant === "assistant") {
     return (
       <MessageAssistant
+        id={id}
         model={model}
         copied={copied}
         copyToClipboard={copyToClipboard}

--- a/app/components/history/command-history.tsx
+++ b/app/components/history/command-history.tsx
@@ -23,7 +23,6 @@ import {
   hasChatsInGroup,
 } from "@/lib/chat-utils/time-grouping"
 import { cn } from "@/lib/utils"
-import React from "react"
 import {
   Check,
   GitBranch,

--- a/app/components/history/drawer-history.tsx
+++ b/app/components/history/drawer-history.tsx
@@ -25,8 +25,8 @@ import {
   Check,
   MagnifyingGlass,
   PencilSimple,
-  PushPinSimple,
-  PushPinSimpleSlash,
+  PushPinSimpleIcon,
+  PushPinSimpleSlashIcon,
   TrashSimple,
   X,
 } from "@phosphor-icons/react"
@@ -143,7 +143,7 @@ export function DrawerHistory({
               {pinnedChats.length > 0 && (
                 <div className="space-y-2">
                   <h3 className="text-muted-foreground flex items-center px-2 text-xs font-medium tracking-wider uppercase">
-                    <PushPinSimple className="mr-1 h-3 w-3" />
+                    <PushPinSimpleIcon className="mr-1 h-3 w-3" />
                     Pinned
                   </h3>
                   {pinnedChats.map((chat) => (
@@ -254,7 +254,7 @@ export function DrawerHistory({
                                   }}
                                   type="button"
                                 >
-                                  <PushPinSimple className="size-4" />
+                                  <PushPinSimpleSlashIcon className="size-4" />
                                 </Button>
                                 <Button
                                   size="icon"
@@ -407,7 +407,7 @@ export function DrawerHistory({
                                       }}
                                       type="button"
                                     >
-                                      <PushPinSimple className="size-4" />
+                                      <PushPinSimpleIcon className="size-4" />
                                     </Button>
                                     <Button
                                       size="icon"

--- a/bun.lock
+++ b/bun.lock
@@ -31,7 +31,6 @@
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-tabs": "^1.1.12",
         "@radix-ui/react-tooltip": "^1.2.7",
-        "@supabase/ssr": "^0.5.2",
         "ai": "^4.3.16",
         "babel-plugin-react-compiler": "^19.1.0-rc.1-rc-af1b7da-20250421",
         "class-variance-authority": "^0.7.1",
@@ -42,7 +41,6 @@
         "exa-js": "^1.8.8",
         "file-type": "^20.5.0",
         "framer-motion": "^12.16.0",
-        "idb-keyval": "^6.2.2",
         "jsdom": "^26.1.0",
         "lucide-react": "^0.503.0",
         "marked": "^15.0.12",
@@ -642,22 +640,6 @@
 
     "@stitches/react": ["@stitches/react@1.2.8", "", { "peerDependencies": { "react": ">= 16.3.0" } }, "sha512-9g9dWI4gsSVe8bNLlb+lMkBYsnIKCZTmvqvDG+Avnn69XfmHZKiaMrx7cgTaddq7aTPPmXiTsbFcUy0xgI4+wA=="],
 
-    "@supabase/auth-js": ["@supabase/auth-js@2.69.1", "", { "dependencies": { "@supabase/node-fetch": "^2.6.14" } }, "sha512-FILtt5WjCNzmReeRLq5wRs3iShwmnWgBvxHfqapC/VoljJl+W8hDAyFmf1NVw3zH+ZjZ05AKxiKxVeb0HNWRMQ=="],
-
-    "@supabase/functions-js": ["@supabase/functions-js@2.4.4", "", { "dependencies": { "@supabase/node-fetch": "^2.6.14" } }, "sha512-WL2p6r4AXNGwop7iwvul2BvOtuJ1YQy8EbOd0dhG1oN1q8el/BIRSFCFnWAMM/vJJlHWLi4ad22sKbKr9mvjoA=="],
-
-    "@supabase/node-fetch": ["@supabase/node-fetch@2.6.15", "", { "dependencies": { "whatwg-url": "^5.0.0" } }, "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ=="],
-
-    "@supabase/postgrest-js": ["@supabase/postgrest-js@1.19.4", "", { "dependencies": { "@supabase/node-fetch": "^2.6.14" } }, "sha512-O4soKqKtZIW3olqmbXXbKugUtByD2jPa8kL2m2c1oozAO11uCcGrRhkZL0kVxjBLrXHE0mdSkFsMj7jDSfyNpw=="],
-
-    "@supabase/realtime-js": ["@supabase/realtime-js@2.11.2", "", { "dependencies": { "@supabase/node-fetch": "^2.6.14", "@types/phoenix": "^1.5.4", "@types/ws": "^8.5.10", "ws": "^8.18.0" } }, "sha512-u/XeuL2Y0QEhXSoIPZZwR6wMXgB+RQbJzG9VErA3VghVt7uRfSVsjeqd7m5GhX3JR6dM/WRmLbVR8URpDWG4+w=="],
-
-    "@supabase/ssr": ["@supabase/ssr@0.5.2", "", { "dependencies": { "@types/cookie": "^0.6.0", "cookie": "^0.7.0" }, "peerDependencies": { "@supabase/supabase-js": "^2.43.4" } }, "sha512-n3plRhr2Bs8Xun1o4S3k1CDv17iH5QY9YcoEvXX3bxV1/5XSasA0mNXYycFmADIdtdE6BG9MRjP5CGIs8qxC8A=="],
-
-    "@supabase/storage-js": ["@supabase/storage-js@2.7.1", "", { "dependencies": { "@supabase/node-fetch": "^2.6.14" } }, "sha512-asYHcyDR1fKqrMpytAS1zjyEfvxuOIp1CIXX7ji4lHHcJKqyk+sLl/Vxgm4sN6u8zvuUtae9e4kDxQP2qrwWBA=="],
-
-    "@supabase/supabase-js": ["@supabase/supabase-js@2.49.4", "", { "dependencies": { "@supabase/auth-js": "2.69.1", "@supabase/functions-js": "2.4.4", "@supabase/node-fetch": "2.6.15", "@supabase/postgrest-js": "1.19.4", "@supabase/realtime-js": "2.11.2", "@supabase/storage-js": "2.7.1" } }, "sha512-jUF0uRUmS8BKt37t01qaZ88H9yV1mbGYnqLeuFWLcdV+x1P4fl0yP9DGtaEhFPZcwSom7u16GkLEH9QJZOqOkw=="],
-
     "@swc/counter": ["@swc/counter@0.1.3", "", {}, "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ=="],
 
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
@@ -798,8 +780,6 @@
 
     "@types/parse-json": ["@types/parse-json@4.0.2", "", {}, "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="],
 
-    "@types/phoenix": ["@types/phoenix@1.6.6", "", {}, "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A=="],
-
     "@types/react": ["@types/react@19.1.7", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-BnsPLV43ddr05N71gaGzyZ5hzkCmGwhMvYc8zmvI8Ci1bRkkDSzDDVfAXfN2tk748OwI7ediiPX6PfT9p0QGVg=="],
 
     "@types/react-dom": ["@types/react-dom@19.1.6", "", { "peerDependencies": { "@types/react": "^19.0.0" } }, "sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw=="],
@@ -809,8 +789,6 @@
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
-
-    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.29.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.10.0", "@typescript-eslint/scope-manager": "8.29.0", "@typescript-eslint/type-utils": "8.29.0", "@typescript-eslint/utils": "8.29.0", "@typescript-eslint/visitor-keys": "8.29.0", "graphemer": "^1.4.0", "ignore": "^5.3.1", "natural-compare": "^1.4.0", "ts-api-utils": "^2.0.1" }, "peerDependencies": { "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0", "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.9.0" } }, "sha512-PAIpk/U7NIS6H7TEtN45SPGLQaHNgB7wSjsQV/8+KYokAb2T/gloOA/Bee2yd4/yKVhPKe5LlaUGhAZk5zmSaQ=="],
 
@@ -1393,8 +1371,6 @@
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
-
-    "idb-keyval": ["idb-keyval@6.2.2", "", {}, "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg=="],
 
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
@@ -2438,10 +2414,6 @@
 
     "@shikijs/transformers/@shikijs/types": ["@shikijs/types@3.2.2", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-a5TiHk7EH5Lso8sHcLHbVNNhWKP0Wi3yVnXnu73g86n3WoDgEra7n3KszyeCGuyoagspQ2fzvy4cpSc8pKhb0A=="],
 
-    "@supabase/node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
-
-    "@supabase/ssr/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
-
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.4.3", "", { "dependencies": { "@emnapi/wasi-threads": "1.0.2", "tslib": "^2.4.0" }, "bundled": true }, "sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.4.3", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ=="],
@@ -2455,8 +2427,6 @@
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "@types/jsdom/@types/node": ["@types/node@20.17.30", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-7zf4YyHA+jvBNfVrk2Gtvs6x7E8V+YDW05bNfG2XkWDJfYRXrTiP/DsB2zSYTaHX0bGIujTBQdMVAhb+j7mwpg=="],
-
-    "@types/ws/@types/node": ["@types/node@20.17.30", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-7zf4YyHA+jvBNfVrk2Gtvs6x7E8V+YDW05bNfG2XkWDJfYRXrTiP/DsB2zSYTaHX0bGIujTBQdMVAhb+j7mwpg=="],
 
     "@typescript-eslint/typescript-estree/fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 
@@ -2562,13 +2532,7 @@
 
     "@lobehub/ui/shiki/@shikijs/types": ["@shikijs/types@3.3.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-KPCGnHG6k06QG/2pnYGbFtFvpVJmC3uIpXrAiPrawETifujPBv0Se2oUxm5qYgjCvGJS9InKvjytOdN+bGuX+Q=="],
 
-    "@supabase/node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
-
-    "@supabase/node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
-
     "@types/jsdom/@types/node/undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
-
-    "@types/ws/@types/node/undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
 
     "@typescript-eslint/typescript-estree/fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -220,6 +220,7 @@ export const searchMessages = query({
     })
   ),
   handler: async (ctx, { query: search, limit = 20 }) => {
+    const safeLimit = Math.min(Math.max(1, limit), 100) // Cap between 1-100
     const userId = await getAuthUserId(ctx)
     if (!userId || search.trim() === "") return []
 
@@ -228,7 +229,7 @@ export const searchMessages = query({
       .withSearchIndex("by_user_content", (q) =>
         q.search("content", search).eq("userId", userId)
       )
-      .take(limit)
+      .take(safeLimit)
 
     return results.map((msg) => ({
       _id: msg._id,

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -223,11 +223,18 @@ export const searchMessages = query({
     const userId = await getAuthUserId(ctx)
     if (!userId || search.trim() === "") return []
 
-    return await ctx.db
+    const results = await ctx.db
       .query("messages")
       .withSearchIndex("by_user_content", (q) =>
         q.search("content", search).eq("userId", userId)
       )
       .take(limit)
+
+    return results.map((msg) => ({
+      _id: msg._id,
+      chatId: msg.chatId,
+      content: msg.content,
+      createdAt: msg.createdAt,
+    }))
   },
 })

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -44,7 +44,12 @@ export default defineSchema({
     parentMessageId: v.optional(v.id("messages")),
     reasoningText: v.optional(v.string()),
     model: v.optional(v.string()),
-  }).index("by_chat_and_created", ["chatId", "createdAt"]),
+  })
+    .index("by_chat_and_created", ["chatId", "createdAt"])
+    .searchIndex("by_user_content", {
+      searchField: "content",
+      filterFields: ["userId", "chatId"],
+    }),
   feedback: defineTable({
     userId: v.id("users"),
     message: v.string(),


### PR DESCRIPTION
## Summary
- add a search index on messages for full-text queries
- add `searchMessages` query in Convex
- update command history to show message snippets from full-text search results
- document the new feature in README
- highlight matched search terms and scroll to results in chat view

## Testing
- `bun run lint` *(fails: several unrelated lint errors)*
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68531765efdc833194780c7f36a70eab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced advanced search functionality allowing users to search message content across all chats.
  - Search results now display relevant message snippets with highlighted search terms.
  - Users can directly navigate to a specific message from search results, with the app scrolling to the selected message.
- **Documentation**
  - Updated the README to highlight the new advanced search feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->