### PR TITLE
feat(ui): anon model selector

### DIFF
--- a/app/components/chat-input/select-model.tsx
+++ b/app/components/chat-input/select-model.tsx
@@ -1,17 +1,5 @@
-import { CaretDownIcon } from '@phosphor-icons/react';
-import { ProviderIcon } from '@/app/components/common/provider-icon';
-import { useBreakpoint } from '@/app/hooks/use-breakpoint';
 import { ModelSelector } from '@/components/common/model-selector';
-import { Button } from '@/components/ui/button';
-import { Popover, PopoverTrigger } from '@/components/ui/popover';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from '@/components/ui/tooltip';
-import { cn } from '@/lib/utils';
-import { MODELS_OPTIONS, PROVIDERS_OPTIONS } from '../../../lib/config';
-import { PopoverContentAuth } from './popover-content-auth';
+// no additional config imports needed
 
 export type SelectModelProps = {
   selectedModel: string;
@@ -22,49 +10,11 @@ export type SelectModelProps = {
 export function SelectModelComponent({
   selectedModel,
   onSelectModel,
-  isUserAuthenticated,
+  isUserAuthenticated: _isUserAuthenticated,
 }: SelectModelProps) {
-  const isMobile = useBreakpoint(768);
-  const modelOption = MODELS_OPTIONS.find((m) => m.id === selectedModel);
-  const providerOption = PROVIDERS_OPTIONS.find(
-    (p) => p.id === modelOption?.provider
-  );
-
-  if (!isUserAuthenticated) {
-    return (
-      <Popover>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <PopoverTrigger asChild>
-              <Button
-                className={cn(
-                  'justify-between rounded-full',
-                  isMobile && 'py-3'
-                )}
-                type="button"
-                variant="outline"
-              >
-                <div className="flex items-center gap-2">
-                  {providerOption && (
-                    <ProviderIcon
-                      className="size-5"
-                      provider={providerOption}
-                    />
-                  )}
-                  <span>{modelOption?.name}</span>
-                </div>
-                <CaretDownIcon className="size-4 opacity-50" />
-              </Button>
-            </PopoverTrigger>
-          </TooltipTrigger>
-          <TooltipContent>Select a model</TooltipContent>
-        </Tooltip>
-
-        <PopoverContentAuth />
-      </Popover>
-    );
-  }
-
+  // Selection handled solely via ModelSelector; availability and provider visuals are managed inside it.
+  // Always render the full model selector for both anonymous and logged-in users.
+  // Premium/locked models are already disabled by availability logic inside the selector.
   return (
     <ModelSelector
       className="rounded-full"

--- a/app/components/chat/chat.tsx
+++ b/app/components/chat/chat.tsx
@@ -472,15 +472,14 @@ export default function Chat() {
   // Model change handler
   const handleModelChange = useCallback(
     async (model: string) => {
-      if (!user || user.isAnonymous) {
-        return;
-      }
-
+      // Allow anonymous and logged-in users to change the model selection in UI.
+      // For new chats (no chatId yet), store temporarily.
       if (!chatId) {
         setTempSelectedModel(model);
         return;
       }
 
+      // For existing chats, persist via mutation. Server validates access.
       await handleModelUpdate(chatId, model, user);
     },
     [chatId, user, handleModelUpdate]

--- a/app/hooks/use-chat-operations.ts
+++ b/app/hooks/use-chat-operations.ts
@@ -38,11 +38,11 @@ export function useChatOperations() {
   );
 
   const handleModelChange = useCallback(
-    async (chatId: string | null, model: string, user: Doc<'users'> | null) => {
-      if (!user || user.isAnonymous) {
-        return false;
-      }
-
+    async (
+      chatId: string | null,
+      model: string,
+      _user: Doc<'users'> | null
+    ) => {
       if (!chatId) {
         // For new chats, this will be handled by temporary state
         return true;

--- a/lib/config/models/deepseek.ts
+++ b/lib/config/models/deepseek.ts
@@ -25,7 +25,7 @@ export const DEEPSEEK_MODELS = [
     subName: 'Reasoning',
     provider: 'openrouter',
     displayProvider: 'deepseek',
-    premium: false,
+    premium: true,
     usesPremiumCredits: false,
     description: `DeepSeek V3.1's thinking mode with deep chain-of-thought reasoning.\nOptimized for complex tasks, multi-step problem solving, and advanced agent capabilities.`,
     apiKeyUsage: { allowUserKey: false, userKeyOnly: false },

--- a/lib/config/models/moonshot.ts
+++ b/lib/config/models/moonshot.ts
@@ -8,7 +8,7 @@ export const MOONSHOT_MODELS = [
     subName: '0711',
     provider: 'openrouter',
     displayProvider: 'moonshotai',
-    premium: false,
+    premium: true,
     usesPremiumCredits: false,
     description: `Moonshot AI's Kimi K2 model.\nOffers agentic tools capabilities for various tasks.`,
     apiKeyUsage: { allowUserKey: false, userKeyOnly: false },

--- a/lib/config/models/qwen.ts
+++ b/lib/config/models/qwen.ts
@@ -20,7 +20,7 @@ export const QWEN_MODELS = [
     subName: 'Thinking',
     provider: 'openrouter',
     displayProvider: 'qwen',
-    premium: false,
+    premium: true,
     usesPremiumCredits: false,
     description: `Qwen's Best Thinking model.\nOffers agentic tools capabilities for various thinking tasks.`,
     apiKeyUsage: { allowUserKey: false, userKeyOnly: false },


### PR DESCRIPTION
- Allow anonymous users to open the model selector and pick allowed models
- Keep premium and user-key-only models disabled via availability logic
- Persist selection for existing chats; store temp selection for new chats
- Upgrade button routes anonymous users to /auth

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Lets anonymous users open the model selector and pick allowed models. Premium and user-key-only models stay disabled; upgrade now routes anonymous users to /auth.

- New Features
  - Show full ModelSelector for all users; locked models remain disabled. Mark DeepSeek V3.1 Reasoning, Moonshot Kimi K2, and Qwen Thinking as premium.
  - Persist model changes for existing chats; keep a temporary selection for new chats.
  - Upgrade flow: anonymous → /auth; non‑premium logged‑in users → checkout.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model selector is always available; all users can change models.
  * For new chats, selected model is saved temporarily until the chat is created.
  * Upgrade panel appears more consistently; anonymous users are redirected to sign in before upgrading.
  * Premium status updated for select models (DeepSeek Reasoning V3.1, Moonshot K2-0711, Qwen 235B Thinking), which may now appear as premium/locked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->