### PR TITLE
chore: prepare for merge to main

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -102,7 +102,7 @@
         "remark-gfm": "^4.0.1",
         "shiki": "^3.22.0",
         "sonner": "^2.0.7",
-        "streamdown": "^2.1.0",
+        "streamdown": "^2.2.0",
         "superjson": "^2.2.6",
         "tailwind-merge": "^3.4.0",
         "tailwindcss": "^4.1.18",
@@ -2963,7 +2963,7 @@
 
     "remeda": ["remeda@2.33.1", "", {}, "sha512-404Eba/HI/blNfbebo586OjEnAhq/x5jN1aIfK4gHnjAP7SADaRfDdIjo8Acpz7hkXgM06MPTwu4IbXamvM9Qw=="],
 
-    "remend": ["remend@1.1.0", "", {}, "sha512-JENGyuIhTwzUfCarW43X4r9cehoqTo9QyYxfNDZSud2AmqeuWjZ5pfybasTa4q0dxTJAj5m8NB+wR+YueAFpxQ=="],
+    "remend": ["remend@1.2.0", "", {}, "sha512-NbKrdWweTRuByPYErzQCNpNtsR9M1QQ0hK2UzmnmlSaEqHnkQ5Korlyi8KpdbOJ0rImJfRy4EAY0uDxYnL9Plw=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
@@ -3097,7 +3097,7 @@
 
     "stop-iteration-iterator": ["stop-iteration-iterator@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "internal-slot": "^1.1.0" } }, "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ=="],
 
-    "streamdown": ["streamdown@2.1.0", "", { "dependencies": { "clsx": "^2.1.1", "hast-util-to-jsx-runtime": "^2.3.6", "html-url-attributes": "^3.0.1", "marked": "^17.0.1", "rehype-harden": "^1.1.7", "rehype-raw": "^7.0.0", "rehype-sanitize": "^6.0.0", "remark-gfm": "^4.0.1", "remark-parse": "^11.0.0", "remark-rehype": "^11.1.2", "remend": "1.1.0", "tailwind-merge": "^3.4.0", "unified": "^11.0.5", "unist-util-visit": "^5.0.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }, "sha512-u9gWd0AmjKg1d+74P44XaPlGrMeC21oDOSIhjGNEYMAttDMzCzlJO6lpTyJ9JkSinQQF65YcK4eOd3q9iTvULw=="],
+    "streamdown": ["streamdown@2.2.0", "", { "dependencies": { "clsx": "^2.1.1", "hast-util-to-jsx-runtime": "^2.3.6", "html-url-attributes": "^3.0.1", "marked": "^17.0.1", "rehype-harden": "^1.1.7", "rehype-raw": "^7.0.0", "rehype-sanitize": "^6.0.0", "remark-gfm": "^4.0.1", "remark-parse": "^11.0.0", "remark-rehype": "^11.1.2", "remend": "1.2.0", "tailwind-merge": "^3.4.0", "unified": "^11.0.5", "unist-util-visit": "^5.0.0", "unist-util-visit-parents": "^6.0.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }, "sha512-Y51o1I/sjpAy4Yn7j7R4TbUl9gcUZ7BTrHS+68IhrUBoYpNQZ28z06vww1MBFu4mSwvgF8xQIxIH2b9S9IHDyQ=="],
 
     "string-argv": ["string-argv@0.3.2", "", {}, "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q=="],
 

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "remark-gfm": "^4.0.1",
     "shiki": "^3.22.0",
     "sonner": "^2.0.7",
-    "streamdown": "^2.1.0",
+    "streamdown": "^2.2.0",
     "superjson": "^2.2.6",
     "tailwind-merge": "^3.4.0",
     "tailwindcss": "^4.1.18",

--- a/src/components/chat/message-assistant.tsx
+++ b/src/components/chat/message-assistant.tsx
@@ -533,6 +533,7 @@ const renderTextPart = (
 	part: { type: "text"; text: string },
 	index: number,
 	id: string,
+	isAnimating: boolean,
 ) => {
 	if (!part.text.trim()) {
 		return null;
@@ -542,6 +543,7 @@ const renderTextPart = (
 		<MessageContent
 			className="relative min-w-full bg-transparent p-0"
 			id={`${id}-text-${index}`}
+			isAnimating={isAnimating}
 			key={`text-${index}`}
 			markdown={true}
 		>
@@ -569,6 +571,7 @@ const renderReasoningPart = (
 				<Markdown
 					className="w-full max-w-none break-words leading-relaxed"
 					id={`${id}-reasoning-${index}`}
+					isAnimating={isPartStreaming}
 				>
 					{part.text}
 				</Markdown>
@@ -812,6 +815,7 @@ const renderPartDirectly = (
 	part: MessageType["parts"][number],
 	index: number,
 	id: string,
+	isAnimating: boolean,
 	partKey: string,
 	reasoningStates: Record<string, boolean>,
 	reasoningStreamingStates: Record<string, boolean>,
@@ -820,7 +824,12 @@ const renderPartDirectly = (
 ) => {
 	switch (part.type) {
 		case "text":
-			return renderTextPart(part as { type: "text"; text: string }, index, id);
+			return renderTextPart(
+				part as { type: "text"; text: string },
+				index,
+				id,
+				isAnimating,
+			);
 
 		case "reasoning":
 			return renderReasoningPart(
@@ -859,6 +868,7 @@ const renderPartInChainOfThought = (
 	part: MessageType["parts"][number],
 	index: number,
 	id: string,
+	isAnimating: boolean,
 	partKey: string,
 	reasoningStates: Record<string, boolean>,
 	reasoningStreamingStates: Record<string, boolean>,
@@ -873,7 +883,12 @@ const renderPartInChainOfThought = (
 					label="Field Report"
 					status="complete"
 				>
-					{renderTextPart(part as { type: "text"; text: string }, index, id)}
+					{renderTextPart(
+						part as { type: "text"; text: string },
+						index,
+						id,
+						isAnimating,
+					)}
 				</ChainOfThoughtStep>
 			);
 
@@ -1294,6 +1309,7 @@ function MessageAssistantInner({
 										part,
 										innerIndex,
 										id,
+										status === "streaming",
 										stableKey,
 										reasoningStates,
 										reasoningStreamingStates,
@@ -1334,6 +1350,7 @@ function MessageAssistantInner({
 										part,
 										innerIndex,
 										id,
+										status === "streaming",
 										stepKey,
 										reasoningStates,
 										reasoningStreamingStates,

--- a/src/components/prompt-kit/markdown.test.tsx
+++ b/src/components/prompt-kit/markdown.test.tsx
@@ -6,8 +6,15 @@ const streamdownSpy = vi.hoisted(() => vi.fn());
 
 vi.mock("streamdown", () => ({
 	Streamdown: (props: {
+		animated?: {
+			animation: string;
+			duration: number;
+			easing: string;
+			sep: "word" | "char";
+		};
 		children?: string;
 		components?: Partial<Record<string, unknown>>;
+		isAnimating?: boolean;
 		parseIncompleteMarkdown?: boolean;
 		plugins?: Record<string, unknown>;
 		remarkPlugins?: unknown[];
@@ -26,12 +33,26 @@ describe("Markdown", () => {
 
 		expect(streamdownSpy).toHaveBeenCalledTimes(1);
 		const props = streamdownSpy.mock.calls[0]?.[0] as {
+			animated?: {
+				animation: string;
+				duration: number;
+				easing: string;
+				sep: "word" | "char";
+			};
+			isAnimating?: boolean;
 			plugins?: Record<string, unknown>;
 			parseIncompleteMarkdown?: boolean;
 			remarkPlugins?: unknown[];
 			components?: Partial<Record<string, unknown>>;
 		};
 
+		expect(props.animated).toEqual({
+			animation: "blurIn",
+			duration: 220,
+			easing: "ease-out",
+			sep: "word",
+		});
+		expect(props.isAnimating).toBe(false);
 		expect(props.parseIncompleteMarkdown).toBe(true);
 		expect(props.plugins).toMatchObject({
 			code: expect.any(Object),
@@ -41,6 +62,17 @@ describe("Markdown", () => {
 		});
 		expect(props.remarkPlugins).toHaveLength(2);
 		expect(typeof props.components?.a).toBe("function");
+	});
+
+	it("passes animation state when streaming", () => {
+		streamdownSpy.mockClear();
+
+		render(<Markdown isAnimating={true}>{"Hello world"}</Markdown>);
+
+		const props = streamdownSpy.mock.calls[0]?.[0] as {
+			isAnimating?: boolean;
+		};
+		expect(props.isAnimating).toBe(true);
 	});
 
 	it("renders multi-block markdown in a single streamdown instance", () => {

--- a/src/components/prompt-kit/markdown.tsx
+++ b/src/components/prompt-kit/markdown.tsx
@@ -1,4 +1,5 @@
 import "katex/dist/katex.css";
+import "streamdown/styles.css";
 import { cjk } from "@streamdown/cjk";
 import { code } from "@streamdown/code";
 import { math } from "@streamdown/math";
@@ -12,12 +13,19 @@ import { Source, SourceContent, SourceTrigger } from "./source";
 
 const STREAMDOWN_PLUGINS = { code, math, cjk, mermaid };
 const REMARK_PLUGINS = [...Object.values(defaultRemarkPlugins), remarkBreaks];
+const STREAMDOWN_ANIMATION = {
+	animation: "blurIn",
+	duration: 220,
+	easing: "ease-out",
+	sep: "word" as const,
+};
 
 export type MarkdownProps = {
 	children: string;
 	id?: string;
 	className?: string;
 	components?: Partial<Components>;
+	isAnimating?: boolean;
 };
 
 const HTTP_REGEX = /^https?:\/\//i;
@@ -55,11 +63,14 @@ function MarkdownComponent({
 	id,
 	className,
 	components = INITIAL_COMPONENTS,
+	isAnimating = false,
 }: MarkdownProps) {
 	return (
 		<div className={cn("markdown-body", className)} id={id}>
 			<Streamdown
+				animated={STREAMDOWN_ANIMATION}
 				components={components}
+				isAnimating={isAnimating}
 				parseIncompleteMarkdown={true}
 				plugins={STREAMDOWN_PLUGINS}
 				remarkPlugins={REMARK_PLUGINS}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds animated, streaming-aware Markdown rendering for assistant messages using Streamdown 2.2.0. Messages now reveal word-by-word while streaming; static messages render normally.

- **New Features**
  - Passes isAnimating to Markdown/Streamdown and enables blurIn animation (220ms, ease-out).
  - Wires streaming state through message-assistant for text and reasoning parts.
  - Imports Streamdown styles and adds tests for animation props.

- **Dependencies**
  - Bumps streamdown to ^2.2.0 and remend to 1.2.0.

<sup>Written for commit 522ee65c5f2858e650d17fd388dddb9115e36c43. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streaming messages now feature animated text display with customizable animation effects.
  * Added configurable animation timing and easing properties for enhanced message visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->