### PR TITLE
feat(models): add GLM-5/M2.5 and update legacy flags

### DIFF
--- a/src/lib/config/models/__tests__/model-providers.test.ts
+++ b/src/lib/config/models/__tests__/model-providers.test.ts
@@ -180,4 +180,27 @@ describe("Model Provider Specific Tests", () => {
       expect(grokModels.length).toBeGreaterThan(0);
     });
   });
+
+  describe("Z.ai Models", () => {
+    it("includes GLM 5 standard and thinking variants", () => {
+      expect(ZAI_MODELS.some((m) => m.id === "glm-5")).toBe(true);
+      expect(ZAI_MODELS.some((m) => m.id === "glm-5-thinking")).toBe(true);
+    });
+
+    it("marks all Z.ai models as legacy except GLM 5, GLM 5 Thinking, and GLM 4.6V", () => {
+      const nonLegacyIds = new Set(ZAI_MODELS.filter((m) => !m.legacy).map((m) => m.id));
+      expect(nonLegacyIds).toEqual(new Set(["glm-5", "glm-5-thinking", "glm-4.6v"]));
+    });
+  });
+
+  describe("MiniMax Models", () => {
+    it("includes MiniMax M2.5", () => {
+      expect(MINIMAX_MODELS.some((m) => m.id === "minimax/minimax-m2.5")).toBe(true);
+    });
+
+    it("marks all MiniMax models as legacy except M2.5 and M2.1", () => {
+      const nonLegacyIds = new Set(MINIMAX_MODELS.filter((m) => !m.legacy).map((m) => m.id));
+      expect(nonLegacyIds).toEqual(new Set(["minimax/minimax-m2.5", "minimax/minimax-m2.1"]));
+    });
+  });
 });

--- a/src/lib/config/models/minimax.ts
+++ b/src/lib/config/models/minimax.ts
@@ -3,6 +3,19 @@ import { openrouter } from "../openrouter";
 
 export const MINIMAX_MODELS = [
   {
+    id: "minimax/minimax-m2.5",
+    name: "MiniMax M2.5",
+    provider: "openrouter",
+    displayProvider: "minimax",
+    premium: true,
+    usesPremiumCredits: false,
+    description:
+      "MiniMax M2.5, released February 12, 2026 with 204,800 context.\nExtends M2.1 from coding into office and multi-agent workflows with stronger planning and token efficiency.",
+    apiKeyUsage: { allowUserKey: false, userKeyOnly: false },
+    features: [TOOL_CALLING_FEATURE, REASONING_FEATURE],
+    api_sdk: openrouter("minimax/minimax-m2.5"),
+  },
+  {
     id: "minimax/minimax-m2.1",
     name: "MiniMax M2.1",
     provider: "openrouter",
@@ -22,6 +35,7 @@ export const MINIMAX_MODELS = [
     displayProvider: "minimax",
     premium: true,
     usesPremiumCredits: false,
+    legacy: true,
     description:
       "MiniMax's high-efficiency model optimized for coding and agentic workflows.\nExcels in multi-step reasoning and tool use.",
     apiKeyUsage: { allowUserKey: false, userKeyOnly: false },

--- a/src/lib/config/models/zai.ts
+++ b/src/lib/config/models/zai.ts
@@ -8,6 +8,33 @@ import { openrouter } from "../openrouter";
 
 export const ZAI_MODELS = [
   {
+    id: "glm-5",
+    name: "GLM 5",
+    provider: "openrouter",
+    displayProvider: "z-ai",
+    premium: true,
+    usesPremiumCredits: false,
+    description:
+      "Z.ai (Zhipu AI) GLM-5 in non-thinking mode.\nReleased on February 11, 2026 with 202,752 context for fast agentic coding and systems workflows.",
+    apiKeyUsage: { allowUserKey: false, userKeyOnly: false },
+    api_sdk: openrouter("z-ai/glm-5"),
+    features: [TOOL_CALLING_FEATURE, REASONING_FEATURE_DISABLED],
+  },
+  {
+    id: "glm-5-thinking",
+    name: "GLM 5",
+    subName: "Thinking",
+    provider: "openrouter",
+    displayProvider: "z-ai",
+    premium: true,
+    usesPremiumCredits: false,
+    description:
+      "Z.ai (Zhipu AI) GLM-5 with thinking enabled.\nReleased on February 11, 2026 with 202,752 context, optimized for long-horizon planning and deep reasoning.",
+    apiKeyUsage: { allowUserKey: false, userKeyOnly: false },
+    api_sdk: openrouter("z-ai/glm-5"),
+    features: [TOOL_CALLING_FEATURE, REASONING_FEATURE],
+  },
+  {
     id: "glm-4.5",
     name: "GLM 4.5",
     provider: "openrouter",
@@ -92,6 +119,7 @@ export const ZAI_MODELS = [
     displayProvider: "z-ai",
     premium: true,
     usesPremiumCredits: false,
+    legacy: true,
     description:
       "Z.AI's latest flagship model with 200K context.\nFeatures enhanced coding, stable multi-step reasoning, superior frontend aesthetics, and think-before-acting capabilities.",
     apiKeyUsage: { allowUserKey: false, userKeyOnly: false },
@@ -106,6 +134,7 @@ export const ZAI_MODELS = [
     displayProvider: "z-ai",
     premium: true,
     usesPremiumCredits: false,
+    legacy: true,
     description:
       "GLM 4.7 with reasoning capabilities enabled.\nFeatures interleaved thinking, preserved thinking across turns, and turn-level thinking control.",
     apiKeyUsage: { allowUserKey: false, userKeyOnly: false },


### PR DESCRIPTION
## Summary
- add `glm-5` and `glm-5-thinking` (premium, standard credits)
- add `minimax/minimax-m2.5` (premium, standard credits)
- mark legacy per request:
  - Z.ai: legacy on all except `glm-5`, `glm-5-thinking`, `glm-4.6v`
  - MiniMax: legacy on all except `minimax/minimax-m2.5`, `minimax/minimax-m2.1`
- add regression tests for model presence + legacy exception sets

## Verification
- `bun run test src/lib/config/models/__tests__/model-providers.test.ts`
- `bun run format`
- `bun run lint`
- `bun run typecheck`
- pre-push hook: full `bun test` (60 files / 1022 tests passed)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Z.ai GLM-5 (standard and Thinking) and MiniMax M2.5, and update legacy flags for Z.ai and MiniMax. This unlocks new premium models and clarifies legacy status, with tests to enforce it.

- **New Features**
  - Add Z.ai GLM-5 and GLM-5 Thinking via OpenRouter (premium, standard credits).
  - Add MiniMax M2.5 via OpenRouter (premium, standard credits).
  - Update legacy flags: Z.ai all legacy except GLM-5, GLM-5 Thinking, GLM-4.6V; MiniMax all legacy except M2.5 and M2.1; add regression tests for model presence and exceptions.

<sup>Written for commit 04e9a3eb61a7446d04dd91c3f0b96d3985649ba2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for new GLM-5 and GLM-5-Thinking AI models with advanced tool calling and reasoning capabilities
  * Added support for the latest MiniMax M2.5 model with enhanced performance and capabilities
  * Marked older model versions as legacy to help you identify and prioritize the most current and recommended available options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->