### PR TITLE
chore: upgrade background agent model to MiniMax M2.5

### DIFF
--- a/convex/scheduled_ai.ts
+++ b/convex/scheduled_ai.ts
@@ -82,7 +82,7 @@ export const executeTask = internalAction({
       const { chatId } = await ctx.runMutation(internal.chats.createChatInternal, {
         userId: task.userId,
         title: `${task.title} - ${currentDate} ${currentTime}`,
-        model: "minimax/minimax-m2.1",
+        model: "minimax/minimax-m2.5",
       });
 
       // Update task with the latest chat ID and set status to 'running'
@@ -172,8 +172,8 @@ export const executeTask = internalAction({
         connectorsStatus,
       );
 
-      // Get MiniMax M2.1 model
-      const selectedModel = MODELS_MAP["minimax/minimax-m2.1"];
+      // Get MiniMax M2.5 model
+      const selectedModel = MODELS_MAP["minimax/minimax-m2.5"];
       if (!selectedModel) {
         // console.log('Kimi K2 0905 model not found');
         return null;


### PR DESCRIPTION
Upgrades the hardcoded background agent model from MiniMax M2.1 to M2.5 in convex/scheduled_ai.ts (lines 85 and 176).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded the background agent model used by scheduled tasks from MiniMax M2.1 to M2.5. Ensures both chat creation and model selection use M2.5 for consistency.

<sup>Written for commit bf812876cc5d754f45f570fa2a557747999153ff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Upgraded AI model to the latest version for enhanced performance and improved response quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->