### PR TITLE
feat(models): replace gemini-3-pro-preview with gemini-3.1-pro-preview

### DIFF
--- a/convex/files.ts
+++ b/convex/files.ts
@@ -107,7 +107,7 @@ const FILE_UPLOAD_MODELS = [
   "gemini-2.5-flash-lite",
   "gemini-2.5-flash-lite-thinking",
   "gemini-2.5-pro",
-  "gemini-3-pro-preview",
+  "gemini-3.1-pro-preview",
 
   // Meta models
   "meta-llama/llama-4-maverick:free",

--- a/src/lib/config/models/__tests__/model-providers.test.ts
+++ b/src/lib/config/models/__tests__/model-providers.test.ts
@@ -248,7 +248,7 @@ describe("Legacy Model Curation", () => {
       [
         "gemini-3-flash-preview",
         "gemini-3-flash-preview-thinking",
-        "gemini-3-pro-preview",
+        "gemini-3.1-pro-preview",
         "nano-banana",
         "nano-banana-pro",
       ].sort(),

--- a/src/lib/config/models/google.ts
+++ b/src/lib/config/models/google.ts
@@ -185,13 +185,13 @@ export const GOOGLE_MODELS = [
     api_sdk: fal.image("fal-ai/gemini-3-pro-image-preview"),
   },
   {
-    id: "gemini-3-pro-preview",
-    name: "Gemini 3 Pro",
+    id: "gemini-3.1-pro-preview",
+    name: "Gemini 3.1 Pro",
     provider: "gemini",
     premium: true,
     usesPremiumCredits: true,
     description:
-      "Early preview of Google's next-generation Gemini 3 model.\nOffers enhanced reasoning and multimodal capabilities.",
+      "Google's most advanced reasoning model capable of solving complex problems.\nFeatures improved agentic capabilities, better thinking, and a 1M token context window.",
     apiKeyUsage: { allowUserKey: true, userKeyOnly: false },
     features: [
       FILE_UPLOAD_FEATURE,
@@ -199,7 +199,7 @@ export const GOOGLE_MODELS = [
       REASONING_FEATURE,
       TOOL_CALLING_FEATURE,
     ],
-    api_sdk: google("gemini-3-pro-preview"),
+    api_sdk: google("gemini-3.1-pro-preview"),
   },
   {
     id: "gemini-3-flash-preview",


### PR DESCRIPTION
Replace Gemini 3 Pro Preview with Gemini 3.1 Pro Preview across model config.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ajanraj/openchat/pull/47" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade Google Gemini Pro to 3.1 Preview across the model config. Switches the model ID and SDK binding, updates the description, and aligns file-upload allowlist and tests to the new model, unlocking improved reasoning and a 1M-token context.

- **Migration**
  - If you reference gemini-3-pro-preview directly, change it to gemini-3.1-pro-preview.

<sup>Written for commit b5187115494445dd3b79afcfa24b6b2abf3e6c8a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

