### PR TITLE
feat(models): add MiniMax M2.7

### DIFF
--- a/src/lib/config/models/__tests__/model-providers.test.ts
+++ b/src/lib/config/models/__tests__/model-providers.test.ts
@@ -217,13 +217,13 @@ describe("Model Provider Specific Tests", () => {
   });
 
   describe("MiniMax Models", () => {
-    it("includes MiniMax M2.5", () => {
-      expect(MINIMAX_MODELS.some((m) => m.id === "minimax/minimax-m2.5")).toBe(true);
+    it("includes MiniMax M2.7", () => {
+      expect(MINIMAX_MODELS.some((m) => m.id === "minimax/minimax-m2.7")).toBe(true);
     });
 
-    it("marks all MiniMax models as legacy except M2.5 and M2.1", () => {
+    it("marks all MiniMax models as legacy except M2.7 and M2.5", () => {
       const nonLegacyIds = new Set(MINIMAX_MODELS.filter((m) => !m.legacy).map((m) => m.id));
-      expect(nonLegacyIds).toEqual(new Set(["minimax/minimax-m2.5", "minimax/minimax-m2.1"]));
+      expect(nonLegacyIds).toEqual(new Set(["minimax/minimax-m2.7", "minimax/minimax-m2.5"]));
     });
   });
 });
@@ -307,9 +307,9 @@ describe("Legacy Model Curation", () => {
     );
   });
 
-  it("keeps only MiniMax M2.5 and M2.1 as non-legacy", () => {
+  it("keeps only MiniMax M2.7 and M2.5 as non-legacy", () => {
     expect(getNonLegacyModelIds(MINIMAX_MODELS)).toEqual(
-      ["minimax/minimax-m2.1", "minimax/minimax-m2.5"].sort(),
+      ["minimax/minimax-m2.5", "minimax/minimax-m2.7"].sort(),
     );
   });
 

--- a/src/lib/config/models/minimax.ts
+++ b/src/lib/config/models/minimax.ts
@@ -3,6 +3,19 @@ import { openrouter } from "../openrouter";
 
 export const MINIMAX_MODELS = [
   {
+    id: "minimax/minimax-m2.7",
+    name: "MiniMax M2.7",
+    provider: "openrouter",
+    displayProvider: "minimax",
+    premium: true,
+    usesPremiumCredits: false,
+    description:
+      "MiniMax M2.7, released March 18, 2026 with 204,800 context.\nBegins MiniMax's recursive self-improvement phase with stronger multi-agent productivity, software engineering, and tool-driven workflows.",
+    apiKeyUsage: { allowUserKey: false, userKeyOnly: false },
+    features: [TOOL_CALLING_FEATURE, REASONING_FEATURE],
+    api_sdk: openrouter("minimax/minimax-m2.7"),
+  },
+  {
     id: "minimax/minimax-m2.5",
     name: "MiniMax M2.5",
     provider: "openrouter",
@@ -22,8 +35,9 @@ export const MINIMAX_MODELS = [
     displayProvider: "minimax",
     premium: true,
     usesPremiumCredits: false,
+    legacy: true,
     description:
-      "MiniMax's latest model with 204K context.\nExcels in multilingual coding, agentic workflows, and clean concise outputs with faster response times.",
+      "MiniMax M2.1, released December 23, 2025 with 204,800 context.\nExcels in multilingual coding, agentic workflows, and cleaner concise outputs with faster response times.",
     apiKeyUsage: { allowUserKey: false, userKeyOnly: false },
     features: [TOOL_CALLING_FEATURE, REASONING_FEATURE],
     api_sdk: openrouter("minimax/minimax-m2.1"),


### PR DESCRIPTION
## Summary
- add MiniMax M2.7 to the MiniMax model config using the live OpenRouter model id
- keep MiniMax's curated non-legacy set to the latest two entries: M2.7 and M2.5
- update MiniMax model-provider tests for presence and legacy curation

## Verification
- `bun run format`
- `bun run lint`
- `bun run typecheck`
- `bun run test src/lib/config/models/__tests__/model-providers.test.ts src/lib/config/__tests__/models.test.ts`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ajanraj/openchat/pull/54" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `minimax/minimax-m2.7` model via `openrouter` and updates MiniMax curation to keep M2.7 and M2.5 as non-legacy. Tests updated to cover presence and curation changes.

- **New Features**
  - Added `minimax/minimax-m2.7` (204,800 context) with tool-calling and reasoning features.
  - Marked M2.1 as legacy; updated provider and curation tests accordingly.

<sup>Written for commit 2da4e429216128d99cdb081fa9a561d5948bc319. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

