### PR TITLE
perf(schema): drop redundant `by_task` index on `task_history`

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -46,7 +46,6 @@ export default defineSchema({
     .index("by_user_and_type", ["userId", "scheduleType"])
     .index("by_next_execution", ["status", "nextExecution"]),
   task_history: defineTable(TaskHistory)
-    .index("by_task", ["taskId"])
     .index("by_task_and_time", ["taskId", "startTime"])
     .index("by_status", ["status"])
     .index("by_execution_id", ["executionId"]),

--- a/convex/task_history.ts
+++ b/convex/task_history.ts
@@ -176,7 +176,7 @@ export const getTaskExecutionStats = query({
     // Get all execution history for this task
     const allHistory = await ctx.db
       .query("task_history")
-      .withIndex("by_task", (q) => q.eq("taskId", args.taskId))
+      .withIndex("by_task_and_time", (q) => q.eq("taskId", args.taskId))
       .collect();
 
     const totalExecutions = allHistory.length;

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -683,7 +683,7 @@ export const deleteAccount = mutation({
         scheduledTasks.map((task) =>
           ctx.db
             .query("task_history")
-            .withIndex("by_task", (q) => q.eq("taskId", task._id))
+            .withIndex("by_task_and_time", (q) => q.eq("taskId", task._id))
             .collect(),
         ),
       )


### PR DESCRIPTION
## What

Removes the `by_task` (`["taskId"]`) index from the `task_history` table and points its
two call sites at the existing `by_task_and_time` (`["taskId", "startTime"]`) index instead:

- `convex/schema.ts` — removed `.index("by_task", ["taskId"])`
- `convex/task_history.ts` (`getTaskExecutionStats`) — `withIndex("by_task", ...)` → `withIndex("by_task_and_time", ...)`
- `convex/users.ts` (account-deletion cleanup) — same switch

## Why

`by_task` is a strict prefix of `by_task_and_time`, so the longer index already answers every
equality lookup on `taskId` — both indexes return the exact same row set for
`q.eq("taskId", ...)`. Meanwhile, `task_history` is an append-heavy log table: every task
execution inserts a row (and patches it on completion), and each extra index adds write
overhead and storage on every one of those operations. The duplicate index buys nothing.

The one thing a prefix index can still be useful for is its distinct ordering
(`_creationTime` within `taskId`, vs. `startTime` for the longer index). I checked both call
sites for this: each one does `.collect()` and then consumes the rows order-insensitively —
`getTaskExecutionStats` computes counts, averages, and a max-by-`startTime` reduction, and the
`users.ts` site just gathers rows to delete them. Nothing observes the ordering change.

## How verified

- `bun run typecheck` (tsc) passes.
- `bun run lint` (oxlint, type-aware) passes.
- Re-ran [convex-doctor](https://github.com/fagnersales/convex-doctor)'s static analysis, which
  originally flagged this as `REDUNDANT_INDEX`; the finding is gone and no new findings
  appeared. Confirmed no other references to `by_task` exist anywhere in `convex/` or `src/`.
- Deploying a schema without the index simply deletes it in Convex; no data migration needed.

## Notes on findings deliberately left alone

This came out of running convex-doctor over the backend. For transparency, the other
prefix-index warnings it raised (`by_user` on `chats`, `profiles`, `connectors`,
`scheduled_tasks`) were **not** applied: those tables' `by_user` queries are used in listing
paths where the within-user `_creationTime` ordering is (or may be) load-bearing, and the
longer indexes (`by_user_and_profile` etc.) would order differently. Dropping those safely
would need an audit of every call site's ordering assumptions, so they're out of scope here.

The tool also reported two error-level `OPTIONALITY_MISMATCH` findings claiming the
`metadata` field in `task_history.ts`'s returns validators is required while the schema has it
optional. Those are false positives: `taskHistoryMetadataValidator` is defined as
`v.optional(v.object({...}))` (`convex/task_history.ts:7`), matching the schema, and rows
inserted without `metadata` (as `createExecutionHistory` does) validate fine. The analyzer
was losing the `v.optional` wrapper when the field validator is referenced through a
module-level identifier — this has since been confirmed and fixed in convex-doctor, and the
fixed version reports zero errors for this repo. No code change was needed here for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dropped the redundant `by_task` index on `task_history` and switched queries to `by_task_and_time` to reduce write/storage overhead without changing results.

- **Refactors**
  - Removed `.index("by_task", ["taskId"])` from `convex/schema.ts`.
  - Updated `getTaskExecutionStats` and account deletion cleanup to `withIndex("by_task_and_time", q.eq("taskId", ...))`.

- **Migration**
  - No data migration needed; Convex drops the index on deploy.

<sup>Written for commit 2ff5dc833c3b4a338be92ec484877450d8a72e88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ajanraj/OpenChat/pull/63?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

